### PR TITLE
Fix mobile hamburger menu display

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -861,6 +861,7 @@ body {
         gap: 0;
     }
     .hamburger {
+        display: flex;
         margin-left: auto;
     }
 


### PR DESCRIPTION
Restore hamburger menu visibility on mobile devices by adding `display: flex` within the mobile media query.

---

**Open Background Agent:** 
[Web](https://www.cursor.com/agents?id=bc-e22e5b13-7dbe-4b3f-b59b-909731c56d6a) · [Cursor](https://cursor.com/background-agent?bcId=bc-e22e5b13-7dbe-4b3f-b59b-909731c56d6a)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)